### PR TITLE
SYG-660: Forcing to use TLS 1.2 on Salesforce calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.2
+
+*   SYG-660: Forcing to use TLS 1.2 on Salesforce calls
+
 ## 1.4.1 (Jun 18, 2013)
 
 *   Fixed a bug with HTTP 413 responses #75 @patronmanager

--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -64,8 +64,11 @@ module Restforce
 
   private
     def faraday_options
-      { :url   => "https://#{@options[:host]}",
-        :proxy => @options[:proxy_uri] }.reject { |k, v| v.nil? }
+      {
+        url: "https://#{@options[:host]}",
+        proxy: @options[:proxy_uri],
+        ssl: { version: :TLSv1_2 }
+      }.reject { |_, v| v.nil? }
     end
   end
 end

--- a/spec/unit/middleware/authentication_spec.rb
+++ b/spec/unit/middleware/authentication_spec.rb
@@ -4,7 +4,9 @@ describe Restforce::Middleware::Authentication do
   let(:options) do
     { :host => 'login.salesforce.com',
       :proxy_uri => 'https://not-a-real-site.com',
-      :authentication_retries => retries }
+      :authentication_retries => retries,
+      ssl: { version: :TLSv1_2 }
+    }
   end
 
   describe '.authenticate!' do
@@ -62,6 +64,10 @@ describe Restforce::Middleware::Authentication do
         its(:handlers) { should include FaradayMiddleware::ParseJson,
           Restforce::Middleware::Logger, Faraday::Adapter::NetHttp }
       end
+    end
+
+    it 'has SSL config set' do
+      expect(connection.ssl[:version]).to eq(:TLSv1_2)
     end
   end
 end


### PR DESCRIPTION
Fixes: https://jira-sage.valiantyscloud.net/browse/SYG-660